### PR TITLE
Environment.md: reset_ps1 function now with whoami

### DIFF
--- a/Environment.md
+++ b/Environment.md
@@ -24,7 +24,7 @@ Add this to your ~/.bashrc:
 
 ```bash
 function reset_ps1 {
-    export PS1='\W$ '
+    export PS1='`whoami` \W$ '
 }
 expr "x$PS1" : 'x\[' > /dev/null && reset_ps1
 


### PR DESCRIPTION
After loading the pyenv, my ps1 loses all user info
instead of:
[masnes@localhost ~]$
I have:
(py3) ~$
after reset_ps1:
~$
This improves things a little by changing it to:
masnes ~$

Adding hostname may also be desireable, but I found that hostname
is too long (localhost.localdomain) in the vm. Hostname -s would
fix this, but I don't trust it.
